### PR TITLE
On start up of Solr you get an ALARMING message about shared memory.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,9 @@ services:
     ports:
      - "8983:8983"
     environment:
+      - SOLR_OPTS=-XX:-UseLargePages
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+
     volumes:
       - ./volumes/fake_shared_fs:/tmp/fake_shared_fs
     depends_on:
@@ -72,6 +74,7 @@ services:
     ports:
      - "8984:8983"
     environment:
+      - SOLR_OPTS=-XX:-UseLargePages
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
     volumes:
       - ./volumes/fake_shared_fs:/tmp/fake_shared_fs
@@ -86,6 +89,7 @@ services:
     ports:
      - "8985:8983"
     environment:
+      - SOLR_OPTS=-XX:-UseLargePages
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
     volumes:
       - ./volumes/fake_shared_fs:/tmp/fake_shared_fs


### PR DESCRIPTION
Turns out it really doesn't matter, but for people who aren't deep in Solr, it's pretty shocking.

This triggered a documentation fix for Solr ;-)  https://github.com/apache/lucene-solr/pull/2304

