### PR TITLE
Suggested improvement for Katas

### DIFF
--- a/katas/000_setting_up_chorus.md
+++ b/katas/000_setting_up_chorus.md
@@ -141,3 +141,15 @@ Now, let's go ahead and make sure we publish the results of our evaluation:
 You can now see a Excel spreadsheet saved to `./rre/target/site/rre-report.xlsx`.  
 
 Bring up http://localhost:7979 and you will see a relatively unexciting empty dashboard.  Don't worry, in our first kata, we'll do a relevancy test and fill this dashboard in.
+
+Last but not least we want to set up what we need to monitor our end user facing applications. We use Prometheus and Grafana for this task. Prometheus is already collecting and storing data. For Grafana we need to set up a user and grant this user administrative rights in Grafana:
+
+```
+curl -u admin:password -S -X POST -H "Content-Type: application/json" -d '{"email":"admin@choruselectronics.com", "name":"Chorus Admin", "role":"admin", "login":"admin@choruselectronics.com", "password":"password", "theme":"light"}' http://localhost:9091/api/admin/users
+curl -u admin:password -S -X PUT -H "Content-Type: application/json" -d '{"isGrafanaAdmin": true}' http://localhost:9091/api/admin/users/2/permissions
+curl -u admin:password -S -X POST -H "Content-Type: application/json" http://localhost:9091/api/users/2/using/1
+```
+
+Check if Grafana is up and running and the freshly created user has access by logging into Grafana at http://localhost:9091 using the username `admin@choruselectronics.com` with the password `password`. We'll dive into the details of observability in [Kata 003 Observability in Chorus](katas/003_observability_in_chorus.md).
+
+Congratulations! You now have Chorus successfully running with its components!

--- a/katas/000_setting_up_chorus.md
+++ b/katas/000_setting_up_chorus.md
@@ -35,6 +35,47 @@ curl --user solr:SolrRocks -X POST http://localhost:8983/api/collections -H 'Con
 
 We now have a two shard _ecommerce_ collection
 
+Before we index some data we are defining some parameters that define our basic relevancy algorithms using ParamSets:
+
+```
+curl --user solr:SolrRocks -X POST http://localhost:8983/solr/ecommerce/config/params -H 'Content-type:application/json'  -d '{
+  "set": {
+    "visible_products":{
+      "fq":["price:*", "-img_500x500:\"\""]
+    }
+  },
+  "set": {
+    "default_algo":{
+      "defType":"edismax",
+      "qf": "id name title product_type short_description ean search_attributes"
+    }
+  },
+  "set": {
+    "mustmatchall_algo":{
+      "deftype":"edismax",
+      "mm":"100%",
+      "qf": "id name title product_type short_description ean search_attributes"
+    }
+  },
+  "set": {
+    "querqy_algo":{
+      "defType":"querqy",
+      "querqy.rewriters":"replace,common_rules,regex_screen_protectors",
+      "querqy.infoLogging":"on",
+      "qf": "id name title product_type short_description ean search_attributes"
+    }
+  },
+  "set": {
+    "querqy_algo_prelive":{
+      "defType":"querqy",
+      "querqy.rewriters":"replace_prelive,common_rules_prelive,regex_screen_protectors",
+      "querqy.infoLogging":"on",
+      "qf": "id name title product_type short_description ean search_attributes"
+    }
+  },
+}'
+```
+
 Grab a sample dataset of 150K products by running from the root of your Chorus checkout:
 
 > wget https://querqy.org/datasets/icecat/icecat-products-150k-20200809.tar.gz

--- a/katas/001_optimize_a_query.md
+++ b/katas/001_optimize_a_query.md
@@ -20,9 +20,9 @@ Since you have already gone through the Movie Demo setup, we'll need to set up a
 
 Go ahead and start a new case by clicking _Relevancy Cases_ drop down and choosing _Create a Case_.  
 
-Let's call the case _Notebook Computers_.   Then, instead of the default Solr instance, let's go ahead and use our Chorus Electronics index using this URL (notice the embedded user credentials):
+Let's call the case _Notebook Computers_.   Then, instead of the default Solr instance, let's go ahead and use our Chorus Electronics index using this URL:
 
-`http://solr:SolrRocks@localhost:8983/solr/ecommerce/select`
+`http://localhost:8983/solr/ecommerce/select`
 
 Click the _ping it_ link to confirm we can access the ecommerce index.
 
@@ -86,9 +86,9 @@ Now that we have a qualitative sense that we've improved our results using Querq
 
 We'll flip back to Quepid to do this.
 
-We need to tell Quepid that we've done some improvement using the `querqy` request handler, instead of the default handler.  For this, we need our _Tune Relevance_ pane.  Click the _Tune Relevance_ link and you will be in the _Query Sandbox_.   Append to the end of the existing query template `q=#$query##` the command to tell Solr to use the Querqy query parser: `&defType=querqy`.   Then click the _Rerun My Searches!_ button.
+We need to tell Quepid that we've done some improvement using the `querqy` request handler, instead of the default handler.  For this, we need our _Tune Relevance_ pane.  Click the _Tune Relevance_ link and you will be in the _Query Sandbox_.   Append to the end of the existing query template `q=#$query##` the command to tell Solr to use the Querqy query parser by specifying the relevant parameter: `&useParams=querqy_algo`.   Then click the _Rerun My Searches!_ button.
 
-Notice that our results have now turned green across the board from red?  Our graph has also improved from our dismal measurement of 0 to the best possible result of 1!
+Notice that our results have now turned green across the board from red?  Our graph has also improved from our dismal measurement of 0 to an almost perfect result of 0.94!
 
 There is a lot to unpack in here that is beyond the scope of this kata.  However bear with me.
 
@@ -98,9 +98,7 @@ RRE uses it's own format of ratings, so in Quepid, click the _Export Case_ optio
 
 You then need to put this ratings into RRE.  First move any ratings file in `./rre/src/etc/ratings/` out of that directory, leaving them in `./rre` is fine.  Then take your freshly exported `Notebook_Computers_rre.json` file and put it in the ratings directory.  
 
-Now, lets look at the RRE setup.  Open up the `Notebook_Computers_rre.json` file and change the index property from `Notebook Computers` to `ecommerce` to match the name of our Solr index and save that change.
-
-We want to regression test our pre Querqy algorithm and our post Querqy algorithm.  So look at the template files in `./rre/src/etc/templates`.  As you can see v1.0 is just the simplistic query.   However v1.1 is using the Querqy enabled request handler.  This is going to let us measure the two against each other.
+Now, lets look at the RRE setup. We want to regression test our pre Querqy algorithm and our post Querqy algorithm.  So look at the template files in `./rre/src/etc/templates`.  As you can see v1.0 is just the simplistic query.   However v1.1 is using the Querqy enabled request handler.  This is going to let us measure the two against each other.
 
 While in this kata we are only running the same set of queries as in Quepid, in real life you would be regression testing those two queries against 100's of other rated queries as well.
 

--- a/katas/003_observability_in_chorus.md
+++ b/katas/003_observability_in_chorus.md
@@ -3,7 +3,13 @@
 This Kata is a more technical one, where we learn how to set up some basic tooling to enable _Observability_ for Chorus.
 What is Observability you ask?  Checkout this blog post by New Relic as an intro: https://blog.newrelic.com/engineering/what-is-observability/
 
-We're assuming you've run the `quickstart.sh` script, or gone through the steps in [Kata 000 Setting up Chorus](katas/000_setting_up_chorus.md) already.
+We're assuming you've run the `quickstart.sh` script. If not, there are some commands to you up & running:
+
+```
+curl -u admin:password -S -X POST -H "Content-Type: application/json" -d '{"email":"admin@choruselectronics.com", "name":"Chorus Admin", "role":"admin", "login":"admin@choruselectronics.com", "password":"password", "theme":"light"}' http://localhost:9091/api/admin/users
+curl -u admin:password -S -X PUT -H "Content-Type: application/json" -d '{"isGrafanaAdmin": true}' http://localhost:9091/api/admin/users/2/permissions
+curl -u admin:password -S -X POST -H "Content-Type: application/json" http://localhost:9091/api/users/2/using/1
+```
 
 Since Solr and Blacklight are the primary end user facing applications, we want to monitor them.   We're going to use two open
 source projects that are widely deployed in "cloud native" setups, Prometheus which gathers metrics and stores
@@ -21,7 +27,7 @@ Now, lets look at Solr.   Pop over to Dashboards icon and Manage, and you'll see
 
 Here you can see lots of low level data, from Jetty web server, to the  JVM and OS metrics being gathered, and whats nice is you can see across our cluster of three Solr nodes running.   
 
-keep going down, past the Node metrics to the Core Metrics, and here you can see details about our setup, for example, the almost 80,000 products that are in the web store.   Go ahead and do some searches, or run the indexing process and you'll see some of the line graphs move up and down.
+Keep going down, past the Node metrics to the Core Metrics, and here you can see details about our setup, for example, the almost 80,000 products that are in the web store.   Go ahead and do some searches, or run the indexing process and you'll see some of the line graphs move up and down.
 
 
 So where does Grafana get this data from?  Well, pop over to the Prometheus dashboard at http://localhost:9090.  Of interest

--- a/katas/003_observability_in_chorus.md
+++ b/katas/003_observability_in_chorus.md
@@ -3,19 +3,13 @@
 This Kata is a more technical one, where we learn how to set up some basic tooling to enable _Observability_ for Chorus.
 What is Observability you ask?  Checkout this blog post by New Relic as an intro: https://blog.newrelic.com/engineering/what-is-observability/
 
-We're assuming you've run the `quickstart.sh` script. If not, there are some commands to you up & running:
-
-```
-curl -u admin:password -S -X POST -H "Content-Type: application/json" -d '{"email":"admin@choruselectronics.com", "name":"Chorus Admin", "role":"admin", "login":"admin@choruselectronics.com", "password":"password", "theme":"light"}' http://localhost:9091/api/admin/users
-curl -u admin:password -S -X PUT -H "Content-Type: application/json" -d '{"isGrafanaAdmin": true}' http://localhost:9091/api/admin/users/2/permissions
-curl -u admin:password -S -X POST -H "Content-Type: application/json" http://localhost:9091/api/users/2/using/1
-```
+We're assuming you've run the `quickstart.sh` script, or gone through the steps in [Kata 000 Setting up Chorus](katas/000_setting_up_chorus.md) already.
 
 Since Solr and Blacklight are the primary end user facing applications, we want to monitor them.   We're going to use two open
 source projects that are widely deployed in "cloud native" setups, Prometheus which gathers metrics and stores
 them, and Grafana, which gives you a really nice dashboard view of that data.   Fortunately there are already some nice dashboards in Grafana for both Solr and Rails (the underlying framework Blacklight is built in) that we've packaged in.
 
-We'll start form the Dashboards in Grafana, and then work our way back to how we get this data.  Log into Grafana at http://localhost:9091 using the username `admin@choruselectronics.com` with the password `password`.   
+We'll start from the Dashboards in Grafana, and then work our way back to how we get this data. Log into Grafana at http://localhost:9091 using the username `admin@choruselectronics.com` with the password `password`.   
 
 Pop over to Dashboards icon and Manage, and you'll see _Rails Metrics_ listed.  
 

--- a/katas/006_adding_custom_query_rules.md
+++ b/katas/006_adding_custom_query_rules.md
@@ -10,6 +10,7 @@ We're going to take advantage of how extendable Querqy is by using a custom rule
 _This is a brand new piece of code for Querqy, so it has limitations we'll document at the end.  We will update this Kata as it evolves towards a 1.0 version._
 
 We'll start by confirming that we've added the Java JAR file that contains this code to our Solr setup in `solr/lib` directory.   You should have a file with the name `querqy-regex-filter-1.1.0-SNAPSHOT.jar`.  If you don't, you'll need to go to the Github project at https://github.com/renekrie/querqy-regex-filter and download and compile the jar file via `mvn package`.  Restart Chorus and you'll be ready to continue.
+If you ran the `quickstart.sh` script you have the lib in your Solr Docker containers in `/opt/querqy/lib/` and the library is integrated via a lib directive in `solrconfig.xml`.
 
 The next step is think about the pattern you want to identify, and how you will tweak the rule.  
 
@@ -65,16 +66,16 @@ Now, we can test this rewriter by issuing a query with the `querqy.rewriters=reg
 curl --user solr:SolrRocks -X GET 'http://localhost:8983/solr/ecommerce/select?q=16:9&defType=querqy&querqy.rewriters=regex_screen_protectors&fl=title,brand,attr_t_aspect_ratio'
 ```
 
-We get back 13 different Kensington screen protectors.   Now, lets pass in some extra query information, like the model number _K58357WW_.   
+We get back 14 different Kensington screen protectors.   Now, lets pass in some extra query information, like the model number _K58357WW_.   
 
 ```
 curl --user solr:SolrRocks -X GET 'http://localhost:8983/solr/ecommerce/select?q=16:9%20K58357WW&defType=querqy&querqy.rewriters=regex_screen_protectors&fl=title,brand,attr_t_aspect_ratio'
 ```
 
-Boom!  We get just a single product result back:
+Boom!  We get just the most relevant product back on top of the hit list:
 
 ```
-"response":{"numFound":1,"start":0,"maxScore":8.232563,"numFoundExact":true,"docs":[
+"response":{"numFound":14,"start":0,"maxScore":8.232563,"numFoundExact":true,"docs":[
     {
       "title":"Kensington K58357WW display privacy filters Frameless display privacy filter 61 cm (24\")",
       "brand":"Kensington",

--- a/katas/007_organize_algorithms_using_paramsets.md
+++ b/katas/007_organize_algorithms_using_paramsets.md
@@ -124,7 +124,7 @@ After you get the score back, double click the Try label and give it a proper na
 
 At the end, if you bring up the _History_ you will see your various tries:
 
-![Tagging Your Queries](009_history_view.png)
+![Tagging Your Queries](007_history_view.png)
 
 You can use this view to flip back and forth and see the differences.   The basic scores should be:
 

--- a/rre/src/etc/templates/v1.1-querqy/template.json
+++ b/rre/src/etc/templates/v1.1-querqy/template.json
@@ -1,6 +1,6 @@
 {
   "q": "$query",
-  "defType": "querqy",
+  "useParams": "querqy_algo",
   "querqy.rewriters": "replace,common_rules"
   "template_version": "v1.1-querqy"
 }


### PR DESCRIPTION
Changes include:

`katas/000_setting_up_chorus.md`:
- Added the definition of the relevancy algorithms (via ParamSets). This step is done in the `quickstart.sh` script but not in the Kata.

`katas/001_optimize_a_query.md`:
- Removed username and password from the URL you use to connect Quepid to. With username and password Quepid cannot connect to Solr.
- Changed the parameter to use when doing relevance tuning in Quepid from `&defType=querqy` to `&useParams=querqy_algo`. Otherwise, I could not spot any difference.
- With the change of the parameter the score changes to 'almost' the best possible of 0.94. That number was adjusted.
- Removed the sentence "Open up the Notebook_Computers_rre.json file and change the index property from Notebook Computers to ecommerce to match the name of our Solr index and save that change." The index property already is correct.
- Replaced the `defType` parameter with the `useParams` parameter to make the evaluation work.

`katas/003_observability_in_chorus.md`:
- Updated the prerequisite section. In Kata 000 the observability part is not initialized with users which leads to a login error when you try to log in.
- The monitoring of the Rails appears to be without any data but I am not sure whether I am missing something.

`katas/006_adding_custom_query_rules.md`:
- Updated description: When you ran the quickstart script, the libs are not in the Solr lib directory. That can be confusing. The query for one specific screen protector still results in 14 screen protectors. Should that be handled by configuration?
- Updated the part of the description mentioning finding only 1 product when you're actually finding 13 products.

`katas/007_organize_algorithms_using_paramsets.md`:
- Fixed 404 with a linked picture