### PR TITLE
Add intellij idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ volumes/solr*
 solr/configsets/ecommerce.zip
 rre/target
 icecat-products-150k-20200809.tar.gz
+.idea


### PR DESCRIPTION
Avoids .idea creating a stale git clone when using Intellij to review chorus files.