### PR TITLE
Use single cloud node of Solr and single node of ZK

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build the stack
         run: ./quickstart.sh
       - name: Test
-        run: docker run --network container:solr1 appropriate/curl -s --retry 10 --retry-connrefused http://localhost:8983/solr/ecommerce/admin/ping
+        run: docker run --network container:solr appropriate/curl -s --retry 10 --retry-connrefused http://localhost:8983/solr/ecommerce/admin/ping
         #run: docker run --network container:quepid appropriate/curl -s --retry 10 --retry-connrefused http://localhost:3000
         #run: docker run --network container:rre appropriate/curl -s --retry 10 --retry-connrefused http://localhost:8080
         #run: docker run --network container:blacklight appropriate/curl --retry 10 --retry-connrefused http://localhost:3000/

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker-compose logs -tf
 If you want to narrow down to just one component of the Chorus stack do:
 ```
 docker-compose ps                       # list out the names of the components
-docker-compose logs -tf solr1 solr2     # tail solr1 and solr2 only
+docker-compose logs -tf solr            # tail solr only
 ```
 
 To destroy your environment (including any volumes created like the mysql db), just run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       - 9394:9394
     command: "foreman s -f Procfile"
     environment:
-      - SOLR_URL=http://solr:SolrRocks@solr1:8983/solr/ecommerce
+      - SOLR_URL=http://solr:SolrRocks@solr:8983/solr/ecommerce
       - PORT=3000
     depends_on:
-      - solr1
+      - solr
 
   mysql:
     container_name: mysql
@@ -41,8 +41,8 @@ services:
       - SMUI_DB_URL=jdbc:mysql://mysql:3306/smui?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
       - SMUI_DB_USER=root
       - SMUI_DB_PASSWORD=password
-      - SMUI_DEPLOY_PRELIVE_SOLR_HOST=solr:SolrRocks@solr1:8983
-      - SMUI_2SOLR_SOLR_HOST=solr:SolrRocks@solr1:8983
+      - SMUI_DEPLOY_PRELIVE_SOLR_HOST=solr:SolrRocks@solr:8983
+      - SMUI_2SOLR_SOLR_HOST=solr:SolrRocks@solr:8983
       - SMUI_TOGGLE_DEPL_PRELIVE=true
       - SMUI_TOGGLE_SPELLING=true
       - SMUI_TOGGLE_DEPL_CUSTOM_SCRIPT=true
@@ -56,101 +56,29 @@ services:
     depends_on:
       - mysql
 
-  solr1:
-    container_name: solr1
+  solr:
+    container_name: solr
     build: ./solr
     ports:
      - "8983:8983"
     environment:
       - SOLR_OPTS=-XX:-UseLargePages
       - SOLR_HEAP=800m
-      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+      - ZK_HOST=zookeeper:2181
       - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true"
-    volumes:
-      - ./volumes/solr1/userfiles:/var/solr/data/userfiles
     depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
+      - zookeeper
       - keycloak
 
-  solr2:
-    container_name: solr2
-    build: ./solr
-    ports:
-     - "8984:8983"
-    environment:
-      - SOLR_OPTS=-XX:-UseLargePages
-      - SOLR_HEAP=800m
-      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
-      - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true"
-    volumes:
-      - ./volumes/solr2/userfiles:/var/solr/data/userfiles
-    depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
-      - keycloak
-
-  solr3:
-    container_name: solr3
-    build: ./solr
-    ports:
-     - "8985:8983"
-    environment:
-      - SOLR_OPTS=-XX:-UseLargePages
-      - SOLR_HEAP=800m
-      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
-      - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true"
-    volumes:
-      - ./volumes/solr3/userfiles:/var/solr/data/userfiles
-    depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
-      - keycloak
-
-  zoo1:
+  zookeeper:
     image: zookeeper:3.6.2
-    container_name: zoo1
-    hostname: zoo1
+    container_name: zookeeper
     ports:
       - 2181:2181
       - 7000:7000
     environment:
-      ZOO_MY_ID: 1
-      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
       ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
       ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
-
-
-  zoo2:
-    image: zookeeper:3.6.2
-    container_name: zoo2
-    hostname: zoo2
-    ports:
-      - 2182:2181
-      - 7001:7000
-    environment:
-      ZOO_MY_ID: 2
-      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
-      ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
-      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
-
-
-  zoo3:
-    image: zookeeper:3.6.2
-    container_name: zoo3
-    hostname: zoo3
-    ports:
-      - 2183:2181
-      - 7002:7000
-    environment:
-      ZOO_MY_ID: 3
-      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
-      ZOO_4LW_COMMANDS_WHITELIST: mntr,conf,ruok
-      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
-
 
   redis:
     container_name: quepid_redis
@@ -185,9 +113,6 @@ services:
       - KEYCLOAK_REALM=chorus
       - KEYCLOAK_SITE=http://keycloak:9080
       - SIGNUP_ENABLED=true
-    links:
-      - mysql
-      - redis
     depends_on:
       - mysql
       - redis
@@ -203,9 +128,9 @@ services:
       - "7979:8080"
     command: "java -jar rre-server-1.1.jar"
     environment:
-      - SOLR_URL=http://solr1:8983/solr/ecommerce
+      - SOLR_URL=http://solr:8983/solr/ecommerce
     depends_on:
-      - solr1
+      - solr
 
   solr-exporter:
     image: solr:8.10.0
@@ -213,14 +138,12 @@ services:
     hostname: solr-exporter
     ports:
      - 9854:9854
-    command: /bin/bash -c "/usr/bin/wait-for-http-200.sh; export JAVA_OPTS='-Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory -Dsolr.httpclient.config=/home/basicauth.properties'; ./contrib/prometheus-exporter/bin/solr-exporter -p 9854 -z zoo1:2181,zoo2:2181,zoo3:2181 -f ./contrib/prometheus-exporter/conf/solr-exporter-config.xml -n 8 -s 15"
+    command: /bin/bash -c "/usr/bin/wait-for-http-200.sh; export JAVA_OPTS='-Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory -Dsolr.httpclient.config=/home/basicauth.properties'; ./contrib/prometheus-exporter/bin/solr-exporter -p 9854 -z zookeeper:2181 -f ./contrib/prometheus-exporter/conf/solr-exporter-config.xml -n 8 -s 15"
     volumes:
       - ./solr-exporter/wait-for-http-200.sh:/usr/bin/wait-for-http-200.sh
       - ./solr-exporter/basicauth.properties:/home/basicauth.properties
     depends_on:
-      - solr1
-      - solr2
-      - solr3
+      - solr
 
   prometheus:
     image: prom/prometheus:v2.22.0

--- a/katas/000_setting_up_chorus.md
+++ b/katas/000_setting_up_chorus.md
@@ -17,8 +17,8 @@ Now we need to load our product data into Chorus.  Open a second terminal window
 Firstly, we're using SolrCloud, so this means a few more steps to set up our `ecommerce` collection, because we are using the management APIs to set up a new collection.  We're also making sure we start with security baked in from the beginning.  Trust me, this is the right way to do it!  Run these steps:
 
 ```sh
-docker cp ./solr/security.json solr1:/security.json
-docker exec solr1 solr zk cp /security.json zk:security.json -z zoo1:2181
+docker cp ./solr/security.json solr:/security.json
+docker exec solr solr zk cp /security.json zk:security.json -z zookeeper:2181
 
 (cd solr/configsets/ecommerce/conf && zip -r - *) > ./solr/configsets/ecommerce.zip
 curl  --user solr:SolrRocks -X PUT --header "Content-Type:application/octet-stream" --data-binary @./solr/configsets/ecommerce.zip "http://localhost:8983/api/cluster/configs/ecommerce"
@@ -28,7 +28,7 @@ curl --user solr:SolrRocks -X POST http://localhost:8983/api/collections -H 'Con
     "create": {
       "name": "ecommerce",
       "config": "ecommerce",
-      "numShards": 2,
+      "numShards": 1,
       "replicationFactor": 1,
       "waitForFinalState": true
     }

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -38,4 +38,4 @@ scrape_configs:
 
   - job_name: 'zookeeper'
     static_configs:
-      - targets: ['zoo1:7000', 'zoo2:7000', 'zoo3:7000']      
+      - targets: ['zookeeper:7000']

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -59,7 +59,7 @@ do
 	shift
 done
 
-services="blacklight solr1 solr2 solr3 smui"
+services="blacklight solr smui"
 if $observability; then
   services="${services} grafana solr-exporter"
 fi
@@ -83,13 +83,13 @@ echo -e "${MAJOR}Waiting for Solr cluster to start up and all three nodes to be 
 
 echo -e "${MAJOR}Setting up security in solr${RESET}"
 echo -e "${MINOR}coping security.json into image${RESET}"
-docker cp ./solr/security.json solr1:/security.json
+docker cp ./solr/security.json solr:/security.json
 
 echo -e "${MINOR}waiting for Keycloak to be available${RESET}"
 ./keycloak/wait-for-keycloak.sh
 
 echo -e "${MINOR}uploading security.json to zookeeper${RESET}"
-docker exec solr1 solr zk cp /security.json zk:security.json -z zoo1:2181
+docker exec solr solr zk cp /security.json zk:security.json -z zookeeper:2181
 
 echo -e "${MINOR}waiting for security.json to be available to all Solr nodes${RESET}"
 ./solr/wait-for-zk-200.sh
@@ -104,7 +104,7 @@ curl --user solr:SolrRocks -X POST http://localhost:8983/api/collections -H 'Con
     "create": {
       "name": "ecommerce",
       "config": "ecommerce",
-      "numShards": 2,
+      "numShards": 1,
       "replicationFactor": 1,
       "waitForFinalState": true
     }

--- a/rre/src/etc/configuration_sets/v1.0/solr-settings.json
+++ b/rre/src/etc/configuration_sets/v1.0/solr-settings.json
@@ -1,4 +1,4 @@
 {
-  "baseUrls": [ "http://solr1:8983/solr" ],
+  "baseUrls": [ "http://solr:8983/solr" ],
   "collectionName": "ecommerce"
 }

--- a/rre/src/etc/configuration_sets/v1.1-querqy/solr-settings.json
+++ b/rre/src/etc/configuration_sets/v1.1-querqy/solr-settings.json
@@ -1,4 +1,4 @@
 {
-  "baseUrls": [ "http://solr1:8983/solr" ],
+  "baseUrls": [ "http://solr:8983/solr" ],
   "collectionName": "ecommerce"
 }

--- a/solr-exporter/wait-for-http-200.sh
+++ b/solr-exporter/wait-for-http-200.sh
@@ -1,1 +1,1 @@
-bash -c 'while [[ "$(curl -s --user solr:SolrRocks -o /dev/null -w ''%{http_code}'' http://solr1:8983/solr/ecommerce/admin/ping)" != "200" ]]; do sleep 5; done'
+bash -c 'while [[ "$(curl -s --user solr:SolrRocks -o /dev/null -w ''%{http_code}'' http://solr:8983/solr/ecommerce/admin/ping)" != "200" ]]; do sleep 5; done'

--- a/solr/wait-for-solr-cluster.sh
+++ b/solr/wait-for-solr-cluster.sh
@@ -1,3 +1,3 @@
 DOT='\033[0;37m.\033[0m'
-while [[ "$(curl -s --user solr:SolrRocks 'http://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS' | jq '.cluster.live_nodes | length ')" != "3" ]]; do printf ${DOT}; sleep 5; done
+while [[ "$(curl -s --user solr:SolrRocks 'http://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS' | jq '.cluster.live_nodes | length ')" != "1" ]]; do printf ${DOT}; sleep 5; done
 echo ""


### PR DESCRIPTION
This uses a single node of Solr and ZK to avoid resource issues when only using 4GB for Docker. Its not clear to me why 3 nodes of Solr and 3 nodes of ZK is necessary to demo all the moving pieces. It adds quite a bit of weight when isn't entirely necessary. I can be convinced to leave the 3 nodes - but just putting this out here since it made the deployment a lot simpler.