### PR TITLE
move away from 7000 as Apple on Monterrey uses it by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     hostname: zoo1
     ports:
       - 2181:2181
-      - 7000:7000
+      - 7001:7000
     environment:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
@@ -129,7 +129,7 @@ services:
     hostname: zoo2
     ports:
       - 2182:2181
-      - 7001:7000
+      - 7002:7000
     environment:
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
@@ -143,7 +143,7 @@ services:
     hostname: zoo3
     ports:
       - 2183:2181
-      - 7002:7000
+      - 7003:7000
     environment:
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181


### PR DESCRIPTION
Turns out ControlCenter, a part of OSX, now defaults to port 7000, so lets not use that one.   Not totally sure we need to keep exposing it however...   that would be the other way to fix it since inside Docker Compose we can use 7000.