### PR TITLE
Changes to make Solr 9 work on Digital Ocean hosts:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       - JAEGER_AGENT_HOST=jaeger
       - JAEGER_AGENT_PORT=5775
       - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true -Dsolr.modules=jwt-auth,jaegertracer-configurator"
-    volumes:
-      - ./volumes/solr1/userfiles:/var/solr/data/userfiles
     depends_on:
       - zoo1
       - zoo2
@@ -96,8 +94,6 @@ services:
       - JAEGER_AGENT_HOST=jaeger
       - JAEGER_AGENT_PORT=5775
       - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true -Dsolr.modules=jwt-auth,jaegertracer-configurator"
-    volumes:
-      - ./volumes/solr2/userfiles:/var/solr/data/userfiles
     depends_on:
       - zoo1
       - zoo2
@@ -120,8 +116,6 @@ services:
       - JAEGER_AGENT_HOST=jaeger
       - JAEGER_AGENT_PORT=5775
       - "SOLR_OPTS=-Dsolr.auth.jwt.allowOutboundHttp=true -Dsolr.modules=jwt-auth,jaegertracer-configurator"
-    volumes:
-      - ./volumes/solr3/userfiles:/var/solr/data/userfiles
     depends_on:
       - zoo1
       - zoo2
@@ -209,12 +203,6 @@ services:
     depends_on:
       - mysql
       - redis
-
-  redis:
-    container_name: quepid_redis
-    image: redis:6.2.6-alpine
-    ports:
-      - 6379:6379
 
   rre:
     container_name: rre

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,9 +1,6 @@
 FROM solr:9.0.0
 
-# This is required by Solr 9, but not in Solr 8!
-RUN mkdir /var/solr/data
-
-COPY solr.xml /var/solr/data/
+COPY --chown=solr:solr solr.xml /var/solr/data/
 
 COPY ./lib/querqy-solr-5.4.lucene900.0-jar-with-dependencies.jar /opt/querqy/lib/
 COPY ./lib/querqy-regex-filter-1.1.0-SNAPSHOT.jar /opt/querqy/lib/


### PR DESCRIPTION
1. Remove unnecessary MKDIR command, change permissions in the COPY command in the Solr Dockerfile.
2. Remove the volume definitions of Solr in the docker-compose.yml file

Additionally, removed the second redis container definition from docker-compose.yml.