### PR TITLE
add admin:password for Solr ;-)

### DIFF
--- a/TECHNICAL_DETAILS.md
+++ b/TECHNICAL_DETAILS.md
@@ -3,13 +3,14 @@
 | Component | Username                    | Password  | Origin             |
 |-----------|-----------------------------|-----------|--------------------|
 | Solr      | solr                        | SolrRocks | security.json      |
+| Solr      | admin                       | password  | security.json      |
 | Quepid    | admin@choruselectronics.com | password  | quickstart.sh      |
 | Grafana   | admin@choruselectronics.com | password  | quickstart.sh      |
 | Keycloak  | admin                       | password  | docker-compose.yml |
 | MySQL     | root                        | password  | docker-compose.yml |
 
 
-`blockUnknown` is false as we want to let RRE run against the `ecommerce` collection.  We have locked down in `security.json` to allow anonymous users only to hit the /ecommerce/select/ end point <-- UPDATE this isn't working.
+`blockUnknown` is false as we want to let RRE run against the `ecommerce` collection.  We have locked down in `security.json` to allow anonymous users only to hit the /ecommerce/select/ end point
 
 When you bring up Solr Admin and then are redirected to Keycloak, when you register and sent back to Solr you are given the `solr-admin` role.
 

--- a/katas/nnn_security_in_chorus.md
+++ b/katas/nnn_security_in_chorus.md
@@ -14,3 +14,5 @@ However, for our users, well we need to be able to manage them in a central loca
 
 
 http://localhost:9080/auth/realms/chorus/.well-known/openid-configuration
+
+https://clemente-biondo.github.io/ for generating solr passwords.

--- a/solr/security.json
+++ b/solr/security.json
@@ -20,9 +20,10 @@
         "scheme": "basic",
         "class": "solr.BasicAuthPlugin",
         "blockUnknown": false,
-        "realm": "Chorus Solr Cluster. Admin Credentials are solr:SolrRocks",
+        "realm": "Chorus Solr Cluster. Admin Credentials are admin:password",
         "credentials": {
-          "solr": "IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="
+          "solr": "IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c=",
+          "admin": "zAm91o0czC72A7Y4dtzicTMDOwk6b4MZbwhSTC7od8Q= emJhcWFoZzBnaGQ4MncwZQ=="
         },
         "forwardCredentials": false
       }
@@ -35,7 +36,8 @@
         "scheme": "basic",
         "class": "solr.RuleBasedAuthorizationPlugin",
         "user-role": {
-          "solr": ["admin", "solr-admin"]
+          "solr": ["admin", "solr-admin"],
+          "admin": ["admin", "solr-admin"]
         }
       },
       {


### PR DESCRIPTION
I constantly forget that I can sue `solr:SolrRocks` since we use either admin:password or admin@choruselectronics.com:password everywehre!