### PR TITLE
Remove unused stopword filter from schema

### DIFF
--- a/solr/configsets/ecommerce/conf/schema.xml
+++ b/solr/configsets/ecommerce/conf/schema.xml
@@ -122,8 +122,6 @@ for demo purposes
   <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
     <analyzer>
       <tokenizer class="solr.StandardTokenizerFactory"/>
-      <!-- Eric doesn't like stopwords. -->
-      <!--filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/-->
       <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
     </analyzer>


### PR DESCRIPTION
Deleted the commented section with the stopwords filter as it is unused.