### PR TITLE
add helpers and settings for readability and check all prerequisites …

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This is because true is usually 1 in most programming contexts, however in linux and bash
+# 0 usually means "success", so let's just be clear.
+TRUE=1
+FALSE=0
+
 # Ansi color code variables
 PROGRAM_NAME="QUICKSTART"
 ERROR='\033[0;31m['$PROGRAM_NAME'] '

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Ansi color code variables
+PROGRAM_NAME="QUICKSTART"
+ERROR='\033[0;31m['$PROGRAM_NAME'] '
+BLUE='\033[0;34m['$PROGRAM_NAME'] '
+LIGHT_GRAY='\033[0;37m['$PROGRAM_NAME']    '
+RESET='\033[0m' # No Color
+BOLD_GREEN='\033[1;32m['$PROGRAM_NAME'] '
+BOLD_RED='\033[1;31m['$PROGRAM_NAME'] '
+
+function prerequisite_is_available() {
+    COMMAND="command -v $1"
+    if [ -x "$($COMMAND)" ]; then
+        return $TRUE
+    else
+        return $FALSE
+    fi
+}
+
+function log_major() {
+    echo -e "${BLUE}$1${RESET}"
+}
+
+function log_minor() {
+    echo -e "${LIGHT_GRAY}$1${RESET}"
+}
+
+function log_awesome() {
+    echo
+    echo -e "${RESET}${BOLD_GREEN}$1${RESET}"
+    echo
+}
+
+function log_green() {
+    echo -e "${BOLD_GREEN}$1${RESET}"
+}
+
+function log_red() {
+    echo -e "${BOLD_RED}$1${RESET}"
+    exit 1
+}
+
+function log_prerequisite_found() {
+    #printf "${BOLD_GREEN}%23s %s ${RESET}\n" "$1 [FOUND]"
+    echo -e "${BOLD_GREEN}Found prerequisite   : $1${RESET}"
+}
+
+function log_prerequisite_missing() {
+    #printf "${BOLD_RED}%25s %s ${RESET}\n" "$1 [MISSING]"
+    echo -e "${BOLD_RED}Missing prerequisite : $1${RESET}"
+}
+
+function check_prerequisites() {
+    set +e
+    PREREQUISITES=("curl" "jq" "docker-compose" "zip")
+    log_major "Checking availability of prerequisites..."
+    COUNT_MISSING_PREQUISITES=0
+    for PREREQUISITE in "${PREREQUISITES[@]}"
+    do
+        prerequisite_is_available "${PREREQUISITE}"
+        PREREQ_AVAILABLE=$?
+        if [ $PREREQ_AVAILABLE = $TRUE ]; then
+            log_prerequisite_found $PREREQUISITE
+        else
+            log_prerequisite_missing "${PREREQUISITE}"
+            COUNT_MISSING_PREQUISITES=$((COUNT_MISSING_PREQUISITES+1))
+        fi
+    done
+
+    if [[ $COUNT_MISSING_PREQUISITES = 0 ]]; then
+        log_green "All prerequisites were found."
+        set -e
+    else
+        log_red "Install missing prerequisites and try again."
+        exit 1
+    fi
+}
+
+function display_help_message() {
+    echo -e "Use the option --with-offline-lab | -lab to include Quepid and RRE services in Chorus."
+    echo -e "Use the option --with-observability | -obs to include Grafana, Prometheus, and Solr Exporter services in Chorus."
+    echo -e "Use the option --shutdown | -s to shutdown and remove the Docker containers and data."
+    echo -e "Use the option --online-deployment | -online to update configuration to run on chorus.dev.o19s.com environment."
+}

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -2,12 +2,16 @@
 
 # This script starts up Chorus and runs through the basic setup tasks.
 
-source settings.sh
 source helpers.sh
 
 set -e
 
 log_awesome "Thank you for trying Chorus! Welcome!"
+
+observability=false
+shutdown=false
+offline_lab=false
+local_deploy=true
 
 while [ ! $# -eq 0 ]
 do

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -40,6 +40,7 @@ do
 	shift
 done
 
+# Function check_prerequisites makes sure that you have curl, jq, docker-compose, and zip installed. See helpers.sh for details.
 check_prerequisites
 
 services="blacklight solr1 solr2 solr3 keycloak smui"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -2,68 +2,41 @@
 
 # This script starts up Chorus and runs through the basic setup tasks.
 
+source settings.sh
+source helpers.sh
+
 set -e
 
-# Ansi color code variables
-ERROR='\033[0;31m[QUICKSTART] '
-MAJOR='\033[0;34m[QUICKSTART] '
-MINOR='\033[0;37m[QUICKSTART]    '
-RESET='\033[0m' # No Color
-
-export DOCKER_SCAN_SUGGEST=false
-
-
-if ! [ -x "$(command -v curl)" ]; then
-  echo '${ERROR}Error: curl is not installed.${RESET}' >&2
-  exit 1
-fi
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo '${ERROR}Error: docker-compose is not installed.${RESET}' >&2
-  exit 1
-fi
-if ! [ -x "$(command -v jq)" ]; then
-  echo '${ERROR}Error: jq is not installed.${RESET}' >&2
-  exit 1
-fi
-if ! [ -x "$(command -v zip)" ]; then
-  echo 'Error: zip is not installed.' >&2
-  exit 1
-fi
-
-observability=false
-shutdown=false
-offline_lab=false
-local_deploy=true
+log_awesome "Thank you for trying Chorus! Welcome!"
 
 while [ ! $# -eq 0 ]
 do
 	case "$1" in
 		--help | -h)
-      echo -e "Use the option --with-offline-lab | -lab to include Quepid and RRE services in Chorus."
-			echo -e "Use the option --with-observability | -obs to include Grafana, Prometheus, and Solr Exporter services in Chorus."
-      echo -e "Use the option --shutdown | -s to shutdown and remove the Docker containers and data."
-      echo -e "Use the option --online-deployment | -online to update configuration to run on chorus.dev.o19s.com environment."
+      display_help_message
 			exit
 			;;
 		--with-observability | -obs)
 			observability=true
-      echo -e "${MAJOR}Running Chorus with observability services enabled${RESET}"
+      log_major "Running Chorus with observability services enabled"
 			;;
     --with-offline-lab | -lab)
 			offline_lab=true
-      echo -e "${MAJOR}Running Chorus with offline lab environment enabled${RESET}"
+      log_major "Running Chorus with offline lab environment enabled"
 			;;
     --online-deployment | -online)
 			local_deploy=false
-      echo -e "${MAJOR}Configuring Chorus for chorus.dev.o19s.com environment${RESET}"
+      log_major "Configuring Chorus for chorus.dev.o19s.com environment"
 			;;
     --shutdown | -s)
 			shutdown=true
-      echo -e "${MAJOR}Shutting down Chorus${RESET}"
+      log_major "Shutting down Chorus"
 			;;
 	esac
 	shift
 done
+
+check_prerequisites
 
 services="blacklight solr1 solr2 solr3 keycloak smui"
 if $observability; then
@@ -75,7 +48,7 @@ if $offline_lab; then
 fi
 
 if ! $local_deploy; then
-  echo -e "${MAJOR}Updating configuration files for online deploy${RESET}"
+  log_major "Updating configuration files for online deploy"
   sed -i.bu 's/localhost:3000/chorus.dev.o19s.com:3000/g'  ./keycloak/realm-config/chorus-realm.json
   sed -i.bu 's/localhost:8983/chorus.dev.o19s.com:8983/g'  ./keycloak/realm-config/chorus-realm.json
   sed -i.bu 's/keycloak:9080/chorus.dev.o19s.com:9080/g'  ./keycloak/wait-for-keycloak.sh
@@ -88,7 +61,6 @@ fi
 
 
 
-
 docker-compose down -v
 if $shutdown; then
   exit
@@ -96,31 +68,31 @@ fi
 
 docker-compose up -d --build ${services}
 
-echo -e "${MAJOR}Waiting for Solr cluster to start up and all three nodes to be online.${RESET}"
+log_major "Waiting for Solr cluster to start up and all three nodes to be online."
 ./solr/wait-for-solr-cluster.sh # Wait for all three Solr nodes to be online
 
-echo -e "${MAJOR}Setting up security in solr${RESET}"
-echo -e "${MINOR}copying security.json into image${RESET}"
+log_major "Setting up security in solr"
+log_minor "copying security.json into image"
 docker cp ./solr/security.json solr1:/security.json
 
 if $local_deploy; then
   ./keycloak/check-for-host-configuration.sh
 fi
 
-echo -e "${MINOR}waiting for Keycloak to be available${RESET}"
+log_minor "waiting for Keycloak to be available"
 ./keycloak/wait-for-keycloak.sh
 
-echo -e "${MINOR}uploading security.json to zookeeper${RESET}"
+log_minor "uploading security.json to zookeeper"
 docker exec solr1 solr zk cp /security.json zk:security.json -z zoo1:2181
 
-echo -e "${MINOR}waiting for security.json to be available to all Solr nodes${RESET}"
+log_minor "waiting for security.json to be available to all Solr nodes"
 ./solr/wait-for-zk-200.sh
 
-echo -e "${MAJOR}Packaging ecommerce configset.${RESET}"
+log_major "Packaging ecommerce configset."
 (cd solr/configsets/ecommerce/conf && zip -r - *) > ./solr/configsets/ecommerce.zip
-echo -e "${MINOR}posting ecommerce.zip configset${RESET}"
+log_minor "posting ecommerce.zip configset"
 curl  --user solr:SolrRocks -X PUT --header "Content-Type:application/octet-stream" --data-binary @./solr/configsets/ecommerce.zip "http://localhost:8983/api/cluster/configs/ecommerce"
-echo -e "${MAJOR}Creating ecommerce collection.${RESET}"
+log_major "Creating ecommerce collection."
 curl --user solr:SolrRocks -X POST http://localhost:8983/api/collections -H 'Content-Type: application/json' -d'
   {
     "create": {
@@ -134,13 +106,13 @@ curl --user solr:SolrRocks -X POST http://localhost:8983/api/collections -H 'Con
 '
 
 if [ ! -f ./icecat-products-150k-20200809.tar.gz ]; then
-    echo -e "${MAJOR}Downloading the sample product data.${RESET}"
+    log_major "Downloading the sample product data."
     curl --progress-bar -o icecat-products-150k-20200809.tar.gz -k https://querqy.org/datasets/icecat/icecat-products-150k-20200809.tar.gz
 fi
-echo -e "${MAJOR}Populating products, please give it a few minutes!${RESET}"
+log_major "Populating products, please give it a few minutes!"
 tar xzf icecat-products-150k-20200809.tar.gz --to-stdout | curl --user solr:SolrRocks 'http://localhost:8983/solr/ecommerce/update?commit=true' --data-binary @- -H 'Content-type:application/json'
 
-echo -e "${MAJOR}Defining relevancy algorithems using ParamSets.${RESET}"
+log_major "Defining relevancy algorithems using ParamSets."
 curl --user solr:SolrRocks -X POST http://localhost:8983/solr/ecommerce/config/params -H 'Content-type:application/json'  -d '{
   "set": {
     "visible_products":{
@@ -179,14 +151,14 @@ curl --user solr:SolrRocks -X POST http://localhost:8983/solr/ecommerce/config/p
 }'
 
 
-echo -e "${MAJOR}Setting up SMUI${RESET}"
+log_major "Setting up SMUI"
 SOLR_INDEX_ID=`curl -S -X PUT -H "Content-Type: application/json" -d '{"name":"ecommerce", "description":"Chorus Webshop"}' http://localhost:9000/api/v1/solr-index | jq -r .returnId`
 curl -S -X PUT -H "Content-Type: application/json" -d '{"name":"product_type"}' http://localhost:9000/api/v1/${SOLR_INDEX_ID}/suggested-solr-field
 curl -S -X PUT -H "Content-Type: application/json" -d '{"name":"title"}' http://localhost:9000/api/v1/${SOLR_INDEX_ID}/suggested-solr-field
 curl -S -X PUT -H "Content-Type: application/json" -d '{"name":"brand"}' http://localhost:9000/api/v1/${SOLR_INDEX_ID}/suggested-solr-field
 
 if $offline_lab; then
-  echo -e "${MAJOR}Setting up Quepid${RESET}"
+  log_major "Setting up Quepid"
   ./mysql/wait-for-mysql.sh
 
   docker-compose run --rm quepid bin/rake db:setup
@@ -197,16 +169,16 @@ if $offline_lab; then
   docker exec quepid thor ratings:import 1 /srv/app/Broad_Query_Set_rated.csv >> /dev/null
 
 
-  echo -e "${MAJOR}Setting up RRE${RESET}"
+  log_major "Setting up RRE"
   docker-compose run rre mvn rre:evaluate
   docker-compose run rre mvn rre-report:report
 fi
 
 if $observability; then
-  echo -e "${MAJOR}Setting up Grafana${RESET}"
+  log_major "Setting up Grafana"
   curl -u admin:password -S -X POST -H "Content-Type: application/json" -d '{"email":"admin@choruselectronics.com", "name":"Chorus Admin", "role":"admin", "login":"admin@choruselectronics.com", "password":"password", "theme":"light"}' http://localhost:9091/api/admin/users
   curl -u admin:password -S -X PUT -H "Content-Type: application/json" -d '{"isGrafanaAdmin": true}' http://localhost:9091/api/admin/users/2/permissions
   curl -u admin:password -S -X POST -H "Content-Type: application/json" http://localhost:9091/api/users/2/using/1
 fi
 
-echo -e "${MAJOR}Welcome to Chorus!${RESET}"
+log_awesome "Chorus is now running!"

--- a/settings.sh
+++ b/settings.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-observability=false
-shutdown=false
-offline_lab=false
-local_deploy=true
-
-TRUE=1
-FALSE=0

--- a/settings.sh
+++ b/settings.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+observability=false
+shutdown=false
+offline_lab=false
+local_deploy=true
+
+TRUE=1
+FALSE=0


### PR DESCRIPTION
…before exiting the script.  This way users don't have to stop and start several times if they are missing any of the prerequisite commands.  Just check them all and tell the user which ones we don't have, and then exit if there are any missing.  This also makes it quicker and easier to add more prerequisite commands later by just adding additional commands to the list of those required. I have more changes to make, but this change is pretty self-contained.   The settings and helpers scripts help move some supporting logic to the side which helps to make quickstart.sh a bit easier to read.