### PR TITLE
keycloak improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,17 +296,24 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
 
   keycloak:
-    platform: ${KEYCLOAK_DOCKER_PLATFORM}
     image: chorus-keycloak
     container_name: keycloak
     build:
       context: ./keycloak
       dockerfile: Dockerfile
-      args:
-        - keycloak_admin_password=${KEYCLOAK_ADMIN_PASSWORD}
-    command: ["start-dev", "--import-realm"]
+    command: start --optimized --import-realm
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
     ports:
       - 9080:9080
+    environment:
+      - KC_HTTP_ENABLED=true
+      - KC_HTTP_PORT=9080
+      - KC_HOSTNAME=keycloak
+      - KC_HOSTNAME_STRICT=false
+      - KC_HOSTNAME_STRICT_HTTPS=false
+      - PROXY_ADDRESS_FORWARDING=true
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=password
+      - DB_VENDOR=h2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,19 +296,17 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
 
   keycloak:
-    image: quay.io/keycloak/keycloak:20.0.3
+    platform: ${KEYCLOAK_DOCKER_PLATFORM}
+    image: chorus-keycloak
     container_name: keycloak
-    hostname: keycloak
+    build:
+      context: ./keycloak
+      dockerfile: Dockerfile
+      args:
+        - keycloak_admin_password=${KEYCLOAK_ADMIN_PASSWORD}
     command: ["start-dev", "--import-realm"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
     ports:
       - 9080:9080
-    environment:
-      KC_HTTP_PORT: 9080
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-      DB_VENDOR: h2
-    volumes:
-      - ./keycloak/realm-config/chorus-realm.json:/opt/keycloak/data/import/chorus-realm.json:ro

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,34 +1,20 @@
-FROM quay.io/keycloak/keycloak:20.0.3 as builder
+FROM quay.io/keycloak/keycloak:20.0.5 as builder
 
 # Enable health and metrics support
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
 
 # Configure a database vendor
-ENV KC_DB=postgres
+#ENV KC_DB=postgres
 
-ARG keycloak_admin_password
-ENV DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD=${keycloak_admin_password}
 
 WORKDIR /opt/keycloak
 # For demonstration purposes only, please make sure to use proper certificates in production instead
-RUN keytool -genkeypair -storepass ${DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD} -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
+RUN keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:20.0.3
+FROM quay.io/keycloak/keycloak:20.0.5
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY realm-config/chorus-realm.json /opt/keycloak/data/import/chorus-realm.json
-
-# Change these values to point to a running postgres instance
-#  ENV KC_DB_URL=<DBURL>
-#  ENV KC_DB_USERNAME=<DBUSERNAME>
-#  ENV KC_DB_PASSWORD=<DBPASSWORD>
-
-# Chorus settings
-ENV KC_HOSTNAME=keycloak
-ENV KC_HTTP_PORT=9080
-ENV DB_VENDOR=h2
-ENV KEYCLOAK_ADMIN=admin
-ENV KEYCLOAK_ADMIN_PASSWORD=${DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD}
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,34 @@
+FROM quay.io/keycloak/keycloak:20.0.3 as builder
+
+# Enable health and metrics support
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+
+# Configure a database vendor
+ENV KC_DB=postgres
+
+ARG keycloak_admin_password
+ENV DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD=${keycloak_admin_password}
+
+WORKDIR /opt/keycloak
+# For demonstration purposes only, please make sure to use proper certificates in production instead
+RUN keytool -genkeypair -storepass ${DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD} -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
+RUN /opt/keycloak/bin/kc.sh build
+
+FROM quay.io/keycloak/keycloak:20.0.3
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+COPY realm-config/chorus-realm.json /opt/keycloak/data/import/chorus-realm.json
+
+# Change these values to point to a running postgres instance
+#  ENV KC_DB_URL=<DBURL>
+#  ENV KC_DB_USERNAME=<DBUSERNAME>
+#  ENV KC_DB_PASSWORD=<DBPASSWORD>
+
+# Chorus settings
+ENV KC_HOSTNAME=keycloak
+ENV KC_HTTP_PORT=9080
+ENV DB_VENDOR=h2
+ENV KEYCLOAK_ADMIN=admin
+ENV KEYCLOAK_ADMIN_PASSWORD=${DOCKER_ENV_KEYCLOAK_ADMIN_PASSWORD}
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -12,9 +12,6 @@ observability=false
 shutdown=false
 offline_lab=false
 local_deploy=true
-apple_silicon=false
-
-KEYCLOAK_ADMIN_PASSWORD=password12345
 
 while [ ! $# -eq 0 ]
 do
@@ -31,10 +28,6 @@ do
 			offline_lab=true
       log_major "Running Chorus with offline lab environment enabled"
 			;;
-    --apple-silicon | -apple)
-      apple_silicon=true
-      log_major "Configuring Chorus for Apple Silicon"
-      ;;
     --online-deployment | -online)
 			local_deploy=false
       log_major "Configuring Chorus for chorus.dev.o19s.com environment"
@@ -60,11 +53,6 @@ if $offline_lab; then
   services="${services} quepid rre"
 fi
 
-if $apple_silicon; then
-  export KEYCLOAK_DOCKER_PLATFORM=linux/arm64/v8
-else
-  export KEYCLOAK_DOCKER_PLATFORM=linux/amd64
-fi
 
 if ! $local_deploy; then
   log_major "Updating configuration files for online deploy"


### PR DESCRIPTION
keycloak is super super slow on Apple Silicon, to the point where it gums up the whole startup process for Chorus.  Setting the right platform and building the keycloak image does the trick.  This is the recommended method anyway, so let's do it all the time, but make sure we pass in the correct platform string to docker-compose.yml via environment variables, then set an arg for docker build for the admin password too, and then pass that down through the use of ARG and ENV in the Dockerfile.  This way the admin password for keycloak can be changed at the top level without much fuss.