### PR TITLE
jaeger process starts regardless of if -obs switch is on or off...   

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
     depends_on:
       - solr1
-      - jaeger
+    #  - jaeger
 
   mysql:
     container_name: mysql
@@ -81,7 +81,7 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      - jaeger
+      #- jaeger
 
   solr2:
     container_name: solr2
@@ -103,7 +103,7 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      - jaeger
+      #- jaeger
 
   solr3:
     container_name: solr3
@@ -125,7 +125,7 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      - jaeger
+      #- jaeger
 
   zoo1:
     image: zookeeper:3.7.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,6 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      #- jaeger
 
   solr2:
     container_name: solr2
@@ -103,7 +102,6 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      #- jaeger
 
   solr3:
     container_name: solr3
@@ -125,7 +123,6 @@ services:
       - zoo2
       - zoo3
       - keycloak
-      #- jaeger
 
   zoo1:
     image: zookeeper:3.7.0


### PR DESCRIPTION
commenting out the depends_on so jaeger doesnt start automatically, only when observatilbity enabled

depends_on was an easy way to control service startup when we first got into this project ;-).   I thought you needed a depends_on or links_to(sp?) to let one service talk to another, but that turns out not to be the case....